### PR TITLE
Fix assets removed when moving field inside a replicator

### DIFF
--- a/AssetsOrganized/resources/assets/js/fieldtype.js
+++ b/AssetsOrganized/resources/assets/js/fieldtype.js
@@ -53,6 +53,10 @@ Vue.component('assets_organized-fieldtype', {
     ready: function() {
         var publish = this.$root.$children.filter(function(filter) { return filter.$options.name === 'publish'; })[0];
 
+        if (!Array.isArray(this.data)) {
+            this.data = this.data.assets;
+        }
+
         if(!this.data[0]) {
             this.data = {};
             this.data.assets = [];


### PR DESCRIPTION
When using inside a replicator, all assets are removed when the field if moved.

This prevent it by checking if the data is an Array and if not take only the `assets ` property